### PR TITLE
starttls on 389 requires ldap scheme

### DIFF
--- a/_examples/basic/main.go
+++ b/_examples/basic/main.go
@@ -16,8 +16,8 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/fifo"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
 )
 
 // Usage:

--- a/_examples/digest/main.go
+++ b/_examples/digest/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/fifo"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/digest"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/digest"
 )
 
 // Usage:

--- a/_examples/jwt/main.go
+++ b/_examples/jwt/main.go
@@ -15,10 +15,10 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/fifo"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/jwt"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/union"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/jwt"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/union"
 )
 
 // Usage:

--- a/_examples/kubernetes/main.go
+++ b/_examples/kubernetes/main.go
@@ -14,8 +14,8 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/fifo"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/kubernetes"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/kubernetes"
 )
 
 // Usage:

--- a/_examples/ldap/main.go
+++ b/_examples/ldap/main.go
@@ -14,8 +14,8 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/fifo"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/ldap"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/ldap"
 )
 
 // Usage:

--- a/_examples/token/main.go
+++ b/_examples/token/main.go
@@ -17,10 +17,10 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/fifo"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/union"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/union"
 )
 
 // Usage:

--- a/_examples/twofactor/main.go
+++ b/_examples/twofactor/main.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/twofactor"
-	"github.com/shaj13/go-guardian/v2/otp"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/twofactor"
+	"github.com/m87carlson/go-guardian/v2/otp"
 )
 
 // Usage:

--- a/_examples/x509/main.go
+++ b/_examples/x509/main.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	gx509 "github.com/shaj13/go-guardian/v2/auth/strategies/x509"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	gx509 "github.com/m87carlson/go-guardian/v2/auth/strategies/x509"
 )
 
 // Usage:

--- a/auth/internal/requestor.go
+++ b/auth/internal/requestor.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // Requester sends an HTTP request to query

--- a/auth/strategies/basic/basic.go
+++ b/auth/strategies/basic/basic.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 var (

--- a/auth/strategies/basic/basic_test.go
+++ b/auth/strategies/basic/basic_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 //nolint:goconst

--- a/auth/strategies/basic/cached.go
+++ b/auth/strategies/basic/cached.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 // ExtensionKey represents a key for the password in info extensions.

--- a/auth/strategies/basic/cached_test.go
+++ b/auth/strategies/basic/cached_test.go
@@ -12,7 +12,7 @@ import (
 	_ "github.com/shaj13/libcache/lru"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 //nolint:goconst

--- a/auth/strategies/basic/example_test.go
+++ b/auth/strategies/basic/example_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/lru"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
 )
 
 func Example() {

--- a/auth/strategies/basic/options.go
+++ b/auth/strategies/basic/options.go
@@ -3,8 +3,8 @@ package basic
 import (
 	"crypto"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 // SetHash apply password hashing using h,

--- a/auth/strategies/digest/digest.go
+++ b/auth/strategies/digest/digest.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // ErrInvalidResponse is returned by Strategy when client authz response does not match server hash.

--- a/auth/strategies/digest/digest_test.go
+++ b/auth/strategies/digest/digest_test.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/shaj13/libcache/lru"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestStartegy(t *testing.T) {

--- a/auth/strategies/digest/options.go
+++ b/auth/strategies/digest/options.go
@@ -3,7 +3,7 @@ package digest
 import (
 	"crypto"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // SetHash set the hashing algorithm to hash the user password.

--- a/auth/strategies/jwt/examples_test.go
+++ b/auth/strategies/jwt/examples_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/jwt"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/jwt"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/lru"

--- a/auth/strategies/jwt/jwt.go
+++ b/auth/strategies/jwt/jwt.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 // GetAuthenticateFunc return function to authenticate request using jwt token.

--- a/auth/strategies/jwt/options.go
+++ b/auth/strategies/jwt/options.go
@@ -3,7 +3,7 @@ package jwt
 import (
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // SetAudience sets token audience(aud),

--- a/auth/strategies/jwt/token.go
+++ b/auth/strategies/jwt/token.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal/jwt"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal/jwt"
 )
 
 const (

--- a/auth/strategies/jwt/token_test.go
+++ b/auth/strategies/jwt/token_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/auth/strategies/kubernetes/example_test.go
+++ b/auth/strategies/kubernetes/example_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/idle"
 
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 func ExampleNew() {

--- a/auth/strategies/kubernetes/kubernetes.go
+++ b/auth/strategies/kubernetes/kubernetes.go
@@ -13,9 +13,9 @@ import (
 	kubeauth "k8s.io/api/authentication/v1"
 	kubemeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 type kubeReview struct {

--- a/auth/strategies/kubernetes/kubernetes_test.go
+++ b/auth/strategies/kubernetes/kubernetes_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestNewKubeReview(t *testing.T) {

--- a/auth/strategies/kubernetes/options.go
+++ b/auth/strategies/kubernetes/options.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 // SetServiceAccountToken sets kubernetes service account token

--- a/auth/strategies/ldap/ldap.go
+++ b/auth/strategies/ldap/ldap.go
@@ -56,9 +56,12 @@ func dial(cfg *Config) (conn, error) {
 	opts := []ldap.DialOpt{}
 
 	if cfg.TLS != nil {
-		scheme = "ldaps"
 		opts = append(opts, ldap.DialWithTLSConfig(cfg.TLS))
 	}
+
+  if cfg.Port == "636" {
+    scheme = "ldaps"
+  }
 
 	addr := fmt.Sprintf("%s://%s:%s", scheme, cfg.Host, cfg.Port)
 	return ldap.DialURL(addr, opts...)

--- a/auth/strategies/ldap/ldap.go
+++ b/auth/strategies/ldap/ldap.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
 
 	"github.com/go-ldap/ldap/v3"
 )

--- a/auth/strategies/oauth2/introspection/claims.go
+++ b/auth/strategies/oauth2/introspection/claims.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 // Claims represents introspection response as defined in RFC 7662.

--- a/auth/strategies/oauth2/introspection/claims_test.go
+++ b/auth/strategies/oauth2/introspection/claims_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 func TestClaimGetUserName(t *testing.T) {

--- a/auth/strategies/oauth2/introspection/example_test.go
+++ b/auth/strategies/oauth2/introspection/example_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/lru"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2/introspection"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2/introspection"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 type ExampleClaims struct {

--- a/auth/strategies/oauth2/introspection/introspection.go
+++ b/auth/strategies/oauth2/introspection/introspection.go
@@ -12,11 +12,11 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 // GetAuthenticateFunc return function to authenticate request using oauth2 token introspection endpoint.

--- a/auth/strategies/oauth2/introspection/options.go
+++ b/auth/strategies/oauth2/introspection/options.go
@@ -4,10 +4,10 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 // SetBasicAuth sets the introspection request's Authorization header to use

--- a/auth/strategies/oauth2/introspection/options_test.go
+++ b/auth/strategies/oauth2/introspection/options_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 func TestSetAuthorizationToken(t *testing.T) {

--- a/auth/strategies/oauth2/jwt/claims.go
+++ b/auth/strategies/oauth2/jwt/claims.go
@@ -3,9 +3,9 @@ package jwt
 import (
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 // Claims represents JWT access token claims

--- a/auth/strategies/oauth2/jwt/claims_test.go
+++ b/auth/strategies/oauth2/jwt/claims_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 func TestGetUserName(t *testing.T) {

--- a/auth/strategies/oauth2/jwt/example_test.go
+++ b/auth/strategies/oauth2/jwt/example_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/lru"
 
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2/jwt"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2/jwt"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 // nolint:lll

--- a/auth/strategies/oauth2/jwt/jwks.go
+++ b/auth/strategies/oauth2/jwt/jwks.go
@@ -10,8 +10,8 @@ import (
 
 	"gopkg.in/square/go-jose.v2"
 
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/internal/header"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/internal/header"
 )
 
 const cacheControl = "cache-control"

--- a/auth/strategies/oauth2/jwt/jwt.go
+++ b/auth/strategies/oauth2/jwt/jwt.go
@@ -11,11 +11,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal/jwt"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal/jwt"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 var (

--- a/auth/strategies/oauth2/jwt/jwt_test.go
+++ b/auth/strategies/oauth2/jwt/jwt_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal/jwt"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal/jwt"
 )
 
 func Test(t *testing.T) {

--- a/auth/strategies/oauth2/jwt/options.go
+++ b/auth/strategies/oauth2/jwt/options.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 // SetHTTPClient sets the underlying http client that used to get JWKS.

--- a/auth/strategies/oauth2/jwt/options_test.go
+++ b/auth/strategies/oauth2/jwt/options_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
 )
 
 func TestSetHTTPClient(t *testing.T) {

--- a/auth/strategies/oauth2/types.go
+++ b/auth/strategies/oauth2/types.go
@@ -3,8 +3,8 @@ package oauth2
 import (
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
 )
 
 var _ ErrorResolver = ResponseError{}

--- a/auth/strategies/oauth2/userinfo/claims.go
+++ b/auth/strategies/oauth2/userinfo/claims.go
@@ -1,9 +1,9 @@
 package userinfo
 
 import (
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 // AddressClaim represents a physical mailing address as defined in OpenID

--- a/auth/strategies/oauth2/userinfo/claims_test.go
+++ b/auth/strategies/oauth2/userinfo/claims_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestClaimGetUserName(t *testing.T) {

--- a/auth/strategies/oauth2/userinfo/example_test.go
+++ b/auth/strategies/oauth2/userinfo/example_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/lru"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2/userinfo"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2/userinfo"
 )
 
 type ExampleClaims struct {

--- a/auth/strategies/oauth2/userinfo/options.go
+++ b/auth/strategies/oauth2/userinfo/options.go
@@ -4,10 +4,10 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 // SetHTTPMethod sets http request's method.

--- a/auth/strategies/oauth2/userinfo/options_test.go
+++ b/auth/strategies/oauth2/userinfo/options_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 func TestSetHTTPMethod(t *testing.T) {

--- a/auth/strategies/oauth2/userinfo/userinfo.go
+++ b/auth/strategies/oauth2/userinfo/userinfo.go
@@ -12,12 +12,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/claims"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
-	"github.com/shaj13/go-guardian/v2/auth/internal/header"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/token"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/claims"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/internal/header"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/token"
 )
 
 const wwwauth = "WWW-Authenticate"

--- a/auth/strategies/oauth2/userinfo/userinfo_test.go
+++ b/auth/strategies/oauth2/userinfo/userinfo_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth/strategies/oauth2"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/oauth2"
 )
 
 func TestUserInfo(t *testing.T) {

--- a/auth/strategies/token/cached.go
+++ b/auth/strategies/token/cached.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // AuthenticateFunc declare function signature to authenticate request using token.

--- a/auth/strategies/token/cached_test.go
+++ b/auth/strategies/token/cached_test.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/shaj13/libcache/lru"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestNewCahced(t *testing.T) {

--- a/auth/strategies/token/example_test.go
+++ b/auth/strategies/token/example_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/shaj13/libcache"
 	_ "github.com/shaj13/libcache/lru"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func Example() {

--- a/auth/strategies/token/options.go
+++ b/auth/strategies/token/options.go
@@ -3,8 +3,8 @@ package token
 import (
 	"crypto"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 // SetType sets the authentication token type or scheme,

--- a/auth/strategies/token/parser.go
+++ b/auth/strategies/token/parser.go
@@ -3,7 +3,7 @@ package token
 import (
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 // Parser parse and extract token from incoming HTTP request.

--- a/auth/strategies/token/scope.go
+++ b/auth/strategies/token/scope.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 const scopesExtName = "x-go-guardian-scopes"

--- a/auth/strategies/token/scope_test.go
+++ b/auth/strategies/token/scope_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestWithGetScope(t *testing.T) {

--- a/auth/strategies/token/static.go
+++ b/auth/strategies/token/static.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // NewStaticFromFile returns static auth.Strategy, populated from a CSV file.

--- a/auth/strategies/token/static_test.go
+++ b/auth/strategies/token/static_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestNewStaticFromFile(t *testing.T) {

--- a/auth/strategies/token/token.go
+++ b/auth/strategies/token/token.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 var (

--- a/auth/strategies/twofactor/example_test.go
+++ b/auth/strategies/twofactor/example_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/basic"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/twofactor"
-	"github.com/shaj13/go-guardian/v2/otp"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/basic"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/twofactor"
+	"github.com/m87carlson/go-guardian/v2/otp"
 )
 
 type OTPManager struct{}

--- a/auth/strategies/twofactor/parser.go
+++ b/auth/strategies/twofactor/parser.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth/internal"
+	"github.com/m87carlson/go-guardian/v2/auth/internal"
 )
 
 // ErrMissingOTP is returned by Parser,

--- a/auth/strategies/twofactor/twofactor.go
+++ b/auth/strategies/twofactor/twofactor.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // ErrInvalidOTP is returned by twofactor strategy,

--- a/auth/strategies/twofactor/twofactor_test.go
+++ b/auth/strategies/twofactor/twofactor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestStrategy(t *testing.T) {

--- a/auth/strategies/union/union.go
+++ b/auth/strategies/union/union.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // MultiError represent multiple errors that occur when attempting to authenticate a request.

--- a/auth/strategies/x509/example_test.go
+++ b/auth/strategies/x509/example_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
-	"github.com/shaj13/go-guardian/v2/auth/strategies/x509"
+	"github.com/m87carlson/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth/strategies/x509"
 )
 
 const (

--- a/auth/strategies/x509/options.go
+++ b/auth/strategies/x509/options.go
@@ -3,7 +3,7 @@ package x509
 import (
 	"regexp"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 // SetInfoBuilder sets x509 info builder.

--- a/auth/strategies/x509/x509.go
+++ b/auth/strategies/x509/x509.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 var (

--- a/auth/strategies/x509/x509_test.go
+++ b/auth/strategies/x509/x509_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/shaj13/go-guardian/v2/auth"
+	"github.com/m87carlson/go-guardian/v2/auth"
 )
 
 func TestStrategyAuthenticate(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shaj13/go-guardian/v2
+module github.com/m87carlson/go-guardian/v2
 
 go 1.13
 

--- a/otp/example_test.go
+++ b/otp/example_test.go
@@ -3,7 +3,7 @@ package otp_test
 import (
 	"fmt"
 
-	"github.com/shaj13/go-guardian/v2/otp"
+	"github.com/m87carlson/go-guardian/v2/otp"
 )
 
 func Example() {


### PR DESCRIPTION
Hello!

Using the ldaps scheme against an LDAP server running on port 389, with StartTLS, will result is a `"Network Error": read tcp x.x.x.x:60677->x.x.x.x:389: read: connection reset by peer` error

I believe this should still be scheme ldap, and ldaps should be used against an LDAP server with SSL enabled on port 636.

