### PR TITLE
Adding Config.URL

### DIFF
--- a/_examples/ldap/main.go
+++ b/_examples/ldap/main.go
@@ -48,8 +48,7 @@ func setupGoGuardian() {
 	cfg := &ldap.Config{
 		BaseDN:       "dc=example,dc=com",
 		BindDN:       "cn=read-only-admin,dc=example,dc=com",
-		Port:         "389",
-		Host:         "ldap.forumsys.com",
+		URL:          "ldap://ldap.forumsys.com:389",
 		BindPassword: "password",
 		Filter:       "(uid=%s)",
 	}

--- a/auth/strategies/ldap/example_test.go
+++ b/auth/strategies/ldap/example_test.go
@@ -9,8 +9,7 @@ func Example() {
 	cfg := Config{
 		BaseDN:       "dc=example,dc=org",
 		BindDN:       "cn=readonly,dc=example,dc=org",
-		Port:         "389",
-		Host:         "127.0.0.1",
+		URL:          "ldap://127.0.0.1:389",
 		BindPassword: "readonly",
 		Filter:       "(cn=%s)",
 	}

--- a/auth/strategies/ldap/ldap.go
+++ b/auth/strategies/ldap/ldap.go
@@ -30,11 +30,9 @@ type conn interface {
 // Config define the configuration to connect to LDAP.
 type Config struct {
 	// Port LDAP server port.
-	//
 	// Deprecated: Use URL instead.
 	Port string
 	// Host LDAP server host.
-	//
 	// Deprecated: Use URL instead.
 	Host string
 	// Specify LDAP URL

--- a/auth/strategies/ldap/ldap.go
+++ b/auth/strategies/ldap/ldap.go
@@ -30,9 +30,15 @@ type conn interface {
 // Config define the configuration to connect to LDAP.
 type Config struct {
 	// Port LDAP server port.
+	//
+	// Deprecated: Use URL instead.
 	Port string
 	// Host LDAP server host.
+	//
+	// Deprecated: Use URL instead.
 	Host string
+	// Specify LDAP URL
+	URL string
 	// TLS configuration, if nil connect without TLS.
 	TLS *tls.Config
 	// BindDN represents LDAP DN for searching for the user DN.
@@ -60,8 +66,11 @@ func dial(cfg *Config) (conn, error) {
 		opts = append(opts, ldap.DialWithTLSConfig(cfg.TLS))
 	}
 
-	addr := fmt.Sprintf("%s://%s:%s", scheme, cfg.Host, cfg.Port)
-	return ldap.DialURL(addr, opts...)
+	if cfg.URL == "" {
+		cfg.URL = fmt.Sprintf("%s://%s:%s", scheme, cfg.Host, cfg.Port)
+	}
+
+	return ldap.DialURL(cfg.URL, opts...)
 }
 
 type client struct {


### PR DESCRIPTION
This should help existing use cases where Host and Port are used,
but we can now use a LDAP URL/URI:

ldap://ldap.example.com:389