### PR TITLE
upgraded go-jose library version to mitigate CVE-2024-28180

### DIFF
--- a/auth/internal/jwt/jwt.go
+++ b/auth/internal/jwt/jwt.go
@@ -4,8 +4,8 @@ import (
 	"crypto"
 	"errors"
 
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"gopkg.in/go-jose/go-jose.v2"
+	"gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
 const headerKID = "kid"

--- a/auth/strategies/oauth2/jwt/jwks.go
+++ b/auth/strategies/oauth2/jwt/jwks.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/go-jose/go-jose.v2"
 
 	"github.com/shaj13/go-guardian/v2/auth/internal"
 	"github.com/shaj13/go-guardian/v2/auth/internal/header"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f
 	github.com/shaj13/libcache v1.0.0
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/square/go-jose.v2 v2.5.1
+	gopkg.in/go-jose/go-jose.v2 v2.6.3
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
 )

--- a/go.sum
+++ b/go.sum
@@ -137,10 +137,10 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs=
+gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
-gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Github security scan (dependabot) and checkmarx has reported a CVE in this library that is introduced through gopkg.in/square/go-jose.v2 v2.5.1.

CVE information can be found here : https://github.com/advisories/GHSA-c5q2-7r4c-mv6g
The version of go-jose library need to updated. The patch containing the fix is gopkg.in/go-jose/go-jose.v2@v2.6.3























